### PR TITLE
Adding source compatibility to Java Utilities build.gradle

### DIFF
--- a/Production/Utilities/JavaUtilities/build.gradle
+++ b/Production/Utilities/JavaUtilities/build.gradle
@@ -16,6 +16,8 @@ apply plugin: 'maven'
 apply from: 'javafx.plugin'
 apply plugin: 'java-library-distribution'
 
+sourceCompatibility = '1.6'
+
 repositories {
     mavenLocal()
     maven { url "http://thaliartifactory.cloudapp.net/artifactory/libs-snapshot" }


### PR DESCRIPTION
We should maintain compatibility with this set of JRE's even for non-android environments (and regardless of the JDK version using to compile).  Discovered when sending binaries compiled with 1.8 to someone running 1.7 - verified rebuilding with this fix resolved the issue.
